### PR TITLE
added scope in error handler propagation fn

### DIFF
--- a/lib/consume.js
+++ b/lib/consume.js
@@ -7,7 +7,7 @@ module.exports = function (options) {
   var args = opts.toArgs(options)
     , kc = spawn('kafkacat', ['-C'].concat(args))
 
-  kc.on('error', kc.stdout.emit.bind(null, 'error'))
+  kc.on('error', kc.stdout.emit.bind(kc.stdout, 'error'))
 
   kc.stderr.on('data', function (data) {
     kc.stdout.emit('error', new Error(data))


### PR DESCRIPTION
Adding scope to error propagating function allows to catch errors uncatchable before.

This fixes Rafflecopter/node-kafkacat#1
